### PR TITLE
Refactor summarization + MCP registry + Qdrant scroller; optimize chunking; split init; remove obsolete docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.86"
 async-trait = "0.1.80"
+async-stream = "0.3"
 axum = "0.7.5"
 dotenvy = "0.15.7"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
@@ -41,6 +42,8 @@ hex = "0.4"
 time = { version = "0.3", features = ["formatting"] }
 ollama-rs = "0.3.1"
 schemars = { version = "0.8", features = ["derive"] }
+futures-core = "0.3"
+futures-util = "0.3"
 
 [[bin]]
 name = "metrics-post"

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -15,6 +15,8 @@ This guide describes the tooling, automation, and expectations for working in th
 ## Repository Layout
 
 - `src/` contains the application code. `main.rs` hosts the HTTP server; `bin/rusty_mem_mcp.rs` exposes the MCP process.
+- `src/qdrant/` wraps the vector-store client; the `scroller` module provides iterator-style access to the scroll API so callers no longer reimplement pagination loops.
+- `src/processing/service.rs` owns the ingestion/summarization pipeline. Use `ProcessingService::try_new()` for synchronous construction, call `init().await` once to provision Qdrant, and fall back to `ProcessingService::new().await` when a convenience helper is acceptable.
 - `scripts/` contains automation: `verify.sh`, `metrics.sh`, and hook wrappers invoked by the linters.
 - `reports/` is reserved for metrics output. The commit-time metrics hook writes to a temporary directory so that the working tree stays clean.
 - `tests/` currently houses the MCP integration test harness.

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -12,6 +12,7 @@
 
 mod format;
 pub mod handlers;
+mod registry;
 mod schemas;
 mod server;
 

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -1,0 +1,38 @@
+use std::{collections::HashMap, future::Future, pin::Pin};
+
+use rmcp::ErrorData as McpError;
+use rmcp::model::{
+    CallToolRequestParam, CallToolResult, ReadResourceRequestParam, ReadResourceResult,
+};
+
+use super::server::RustyMemMcpServer;
+
+pub type ResourceFuture =
+    Pin<Box<dyn Future<Output = Result<ReadResourceResult, McpError>> + Send>>;
+pub type ToolFuture = Pin<Box<dyn Future<Output = Result<CallToolResult, McpError>> + Send>>;
+
+pub type ResourceHandler = fn(&RustyMemMcpServer, ReadResourceRequestParam) -> ResourceFuture;
+pub type ToolHandler = fn(&RustyMemMcpServer, CallToolRequestParam) -> ToolFuture;
+
+/// Registry mapping resource URIs and tool names to handler functions.
+pub struct Registry {
+    pub resources: HashMap<&'static str, ResourceHandler>,
+    pub tools: HashMap<&'static str, ToolHandler>,
+}
+
+impl Registry {
+    pub fn new() -> Self {
+        Self {
+            resources: HashMap::new(),
+            tools: HashMap::new(),
+        }
+    }
+
+    pub fn register_resource(&mut self, uri: &'static str, handler: ResourceHandler) {
+        self.resources.insert(uri, handler);
+    }
+
+    pub fn register_tool(&mut self, name: &'static str, handler: ToolHandler) {
+        self.tools.insert(name, handler);
+    }
+}

--- a/src/processing/summarize/idempotency.rs
+++ b/src/processing/summarize/idempotency.rs
@@ -1,0 +1,46 @@
+use crate::qdrant::types::QdrantError;
+use crate::qdrant::{self, QdrantService, SearchFilterArgs};
+use serde_json::json;
+
+/// Construct the standard idempotency tag used for semantic summaries.
+pub(crate) fn idempotency_tag(key: &str) -> String {
+    format!("summary:{key}")
+}
+
+/// Look up an existing semantic summary that matches the idempotency tag.
+pub(crate) async fn find_existing_summary(
+    qdrant: &QdrantService,
+    collection: &str,
+    project_id: Option<&str>,
+    tag: &str,
+) -> Result<Option<(String, String)>, QdrantError> {
+    let filter = qdrant::build_search_filter(&SearchFilterArgs {
+        project_id: project_id.map(|value| value.to_string()),
+        memory_type: Some("semantic".into()),
+        tags: Some(vec![tag.to_string()]),
+        time_range: None,
+    });
+
+    let existing = qdrant
+        .scroll_payloads_with_ids(collection, json!(["text"]), filter)
+        .await?;
+
+    Ok(existing.into_iter().next().map(|(id, payload)| {
+        let text = payload
+            .get("text")
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .to_string();
+        (id, text)
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idempotency_tag_applies_prefix() {
+        assert_eq!(idempotency_tag("abc"), "summary:abc");
+    }
+}

--- a/src/processing/summarize/io.rs
+++ b/src/processing/summarize/io.rs
@@ -1,0 +1,91 @@
+use crate::qdrant::types::{PayloadOverrides, QdrantError};
+use crate::qdrant::{self, PointInsert, QdrantService, SearchFilterArgs};
+use serde_json::{Map, Value, json};
+
+use super::{EpisodicMemory, sort_memories};
+
+/// Fetch episodic memories from Qdrant, sort chronologically, and apply the requested limit.
+pub(crate) async fn fetch_episodic_items(
+    qdrant: &QdrantService,
+    collection: &str,
+    fields: Value,
+    filter: Option<Value>,
+    limit: usize,
+) -> Result<Vec<EpisodicMemory>, QdrantError> {
+    let mut items = qdrant
+        .scroll_payloads_with_ids(collection, fields, filter)
+        .await?
+        .into_iter()
+        .filter_map(|(id, payload)| map_payload_into_memory(id, payload))
+        .collect::<Vec<_>>();
+
+    sort_memories(&mut items);
+    if items.len() > limit {
+        items.truncate(limit);
+    }
+
+    Ok(items)
+}
+
+fn map_payload_into_memory(
+    memory_id: String,
+    payload: Map<String, Value>,
+) -> Option<EpisodicMemory> {
+    let text = payload
+        .get("text")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    if text.trim().is_empty() {
+        return None;
+    }
+
+    let timestamp = payload
+        .get("timestamp")
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string());
+
+    Some(EpisodicMemory::new(memory_id, text, timestamp))
+}
+
+/// Persist a semantic summary and resolve the resulting memory identifier.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn persist_semantic_summary(
+    qdrant: &QdrantService,
+    collection: &str,
+    summary_text: &str,
+    vector: Vec<f32>,
+    chunk_hash: String,
+    overrides: &PayloadOverrides,
+    project_id: Option<&str>,
+    idempotency_tag: &str,
+) -> Result<String, QdrantError> {
+    qdrant
+        .index_points(
+            collection,
+            vec![PointInsert {
+                text: summary_text.to_string(),
+                chunk_hash,
+                vector,
+            }],
+            overrides,
+        )
+        .await?;
+
+    let filter = qdrant::build_search_filter(&SearchFilterArgs {
+        project_id: project_id.map(|value| value.to_string()),
+        memory_type: Some("semantic".into()),
+        tags: Some(vec![idempotency_tag.to_string()]),
+        time_range: None,
+    });
+
+    let resolve = qdrant
+        .scroll_payloads_with_ids(collection, json!(["text"]), filter)
+        .await?;
+
+    Ok(resolve
+        .into_iter()
+        .map(|(id, _)| id)
+        .next()
+        .unwrap_or_default())
+}

--- a/src/processing/summarize/mod.rs
+++ b/src/processing/summarize/mod.rs
@@ -1,5 +1,13 @@
 //! Helper routines for the summarization pipeline.
 
+pub(crate) mod idempotency;
+pub(crate) mod io;
+pub(crate) mod strategy;
+
+pub(crate) use idempotency::{find_existing_summary, idempotency_tag};
+pub(crate) use io::{fetch_episodic_items, persist_semantic_summary};
+pub(crate) use strategy::select_summary_strategy;
+
 use crate::processing::types::SearchTimeRange;
 use sha2::{Digest, Sha256};
 use std::cmp::Ordering;

--- a/src/processing/summarize/strategy.rs
+++ b/src/processing/summarize/strategy.rs
@@ -1,0 +1,83 @@
+use crate::config::{Config, SummarizationProvider};
+use crate::processing::{SummarizeRequest, SummarizeStrategy};
+use crate::summarization::{
+    SummarizationRequest as LlmSummarizationRequest, get_summarization_client,
+};
+
+use super::{EpisodicMemory, build_abstractive_prompt, build_extractive_summary};
+
+/// Result of applying a summarization strategy selection.
+pub(crate) struct StrategyResult {
+    pub summary_text: String,
+    pub strategy: SummarizeStrategy,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+}
+
+/// Choose between abstractive and extractive summarization.
+pub(crate) async fn select_summary_strategy(
+    request: &SummarizeRequest,
+    items: &[EpisodicMemory],
+    config: &Config,
+) -> StrategyResult {
+    let mut chosen_strategy = request.strategy.clone().unwrap_or(SummarizeStrategy::Auto);
+    let mut provider = request.provider.clone();
+    let mut model = request.model.clone();
+    let mut summary_text = String::new();
+
+    if matches!(
+        chosen_strategy,
+        SummarizeStrategy::Auto | SummarizeStrategy::Abstractive
+    ) && matches!(config.summarization_provider, SummarizationProvider::Ollama)
+    {
+        if model.is_none() {
+            model = config.summarization_model.clone();
+        }
+        if provider.is_none() {
+            provider = Some("ollama".into());
+        }
+        if let (Some(model_name), Some(client)) = (model.clone(), get_summarization_client()) {
+            let max_words = request.max_words.unwrap_or(config.summarization_max_words);
+            let prompt = build_abstractive_prompt(
+                request.project_id.as_deref().unwrap_or("default"),
+                &request.time_range,
+                max_words,
+                items,
+            );
+            match client
+                .generate_summary(LlmSummarizationRequest {
+                    model: model_name.clone(),
+                    prompt,
+                    max_words,
+                })
+                .await
+            {
+                Ok(text) => {
+                    summary_text = text;
+                    chosen_strategy = SummarizeStrategy::Abstractive;
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        "Abstractive summarization failed; falling back to extractive"
+                    );
+                }
+            }
+        }
+    }
+
+    if summary_text.is_empty() {
+        let max_words = request.max_words.unwrap_or(config.summarization_max_words);
+        summary_text = build_extractive_summary(items, max_words);
+        if matches!(chosen_strategy, SummarizeStrategy::Auto) {
+            chosen_strategy = SummarizeStrategy::Extractive;
+        }
+    }
+
+    StrategyResult {
+        summary_text,
+        strategy: chosen_strategy,
+        provider,
+        model,
+    }
+}

--- a/src/qdrant/mod.rs
+++ b/src/qdrant/mod.rs
@@ -3,6 +3,8 @@
 pub mod client;
 pub mod filters;
 pub mod payload;
+/// Streaming helpers for Qdrant scroll pagination.
+pub mod scroller;
 pub mod types;
 
 pub use client::QdrantService;

--- a/src/qdrant/scroller.rs
+++ b/src/qdrant/scroller.rs
@@ -1,0 +1,261 @@
+//! Streaming helpers for iterating Qdrant scroll endpoints without manual loops.
+
+use async_stream::try_stream;
+use futures_core::Stream;
+use reqwest::Method;
+use serde_json::{Map, Value, json};
+
+use super::client::QdrantService;
+use super::client::stringify_point_id;
+use super::types::{QdrantError, ScrollResponse};
+
+const DEFAULT_SCROLL_LIMIT: usize = 512;
+
+/// Stream Qdrant payloads for a collection using the scroll API.
+pub fn stream_payloads<'a>(
+    service: &'a QdrantService,
+    collection: &'a str,
+    with_payload: Value,
+    filter: Option<Value>,
+) -> impl Stream<Item = Result<Map<String, Value>, QdrantError>> + 'a {
+    try_stream! {
+        let mut offset: Option<Value> = None;
+        let payload_template = with_payload;
+        let filter_body = filter.unwrap_or_else(|| json!({ "must": [] }));
+
+        loop {
+            let mut body = json!({
+                "with_payload": payload_template.clone(),
+                "with_vector": false,
+                "limit": DEFAULT_SCROLL_LIMIT,
+                "filter": filter_body.clone(),
+                "order_by": [
+                    { "key": "timestamp", "direction": "asc" }
+                ],
+            });
+
+            body.as_object_mut()
+                .expect("scroll body is object")
+                .insert("offset".into(), offset.clone().unwrap_or(Value::Null));
+
+            let mut request = service.client.request(
+                Method::POST,
+                format_endpoint(&service.base_url, &format!("collections/{collection}/points/scroll")),
+            );
+
+            if let Some(api_key) = &service.api_key && !api_key.is_empty() {
+                request = request.header("api-key", api_key);
+            }
+
+            let response = request.json(&body).send().await?;
+
+            let status = response.status();
+            if status.is_success() {
+                let ScrollResponse { result } = response.json().await?;
+                for point in result.points {
+                    if let Some(payload) = point.payload {
+                        yield payload;
+                    }
+                }
+
+                match result.next_page_offset {
+                    Some(next) => offset = Some(next),
+                    None => break,
+                }
+            } else {
+                let body = response.text().await.unwrap_or_default();
+                tracing::error!(collection = collection, status = %status, "Failed to scroll payloads via stream");
+                Err(QdrantError::UnexpectedStatus { status, body })?;
+            }
+        }
+    }
+}
+
+/// Stream Qdrant payloads along with their point identifiers.
+pub fn stream_payloads_with_ids<'a>(
+    service: &'a QdrantService,
+    collection: &'a str,
+    with_payload: Value,
+    filter: Option<Value>,
+) -> impl Stream<Item = Result<(String, Map<String, Value>), QdrantError>> + 'a {
+    try_stream! {
+        let mut offset: Option<Value> = None;
+        let payload_template = with_payload;
+        let filter_body = filter.unwrap_or_else(|| json!({ "must": [] }));
+
+        loop {
+            let mut body = json!({
+                "with_payload": payload_template.clone(),
+                "with_vector": false,
+                "limit": DEFAULT_SCROLL_LIMIT,
+                "filter": filter_body.clone(),
+                "order_by": [
+                    { "key": "timestamp", "direction": "asc" }
+                ],
+            });
+
+            body.as_object_mut()
+                .expect("scroll body is object")
+                .insert("offset".into(), offset.clone().unwrap_or(Value::Null));
+
+            let mut request = service.client.request(
+                Method::POST,
+                format_endpoint(&service.base_url, &format!("collections/{collection}/points/scroll")),
+            );
+
+            if let Some(api_key) = &service.api_key && !api_key.is_empty() {
+                request = request.header("api-key", api_key);
+            }
+
+            let response = request.json(&body).send().await?;
+
+            let status = response.status();
+            if status.is_success() {
+                let ScrollResponse { result } = response.json().await?;
+                for point in result.points {
+                    if let (Some(id), Some(payload)) = (point.id, point.payload) {
+                        yield (stringify_point_id(id), payload);
+                    }
+                }
+
+                match result.next_page_offset {
+                    Some(next) => offset = Some(next),
+                    None => break,
+                }
+            } else {
+                let body = response.text().await.unwrap_or_default();
+                tracing::error!(collection = collection, status = %status, "Failed to scroll payloads with ids via stream");
+                Err(QdrantError::UnexpectedStatus { status, body })?;
+            }
+        }
+    }
+}
+
+fn format_endpoint(base: &str, path: &str) -> String {
+    let base = base.trim_end_matches('/');
+    let path = path.trim_start_matches('/');
+    format!("{base}/{path}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::{pin_mut, stream::StreamExt};
+    use httpmock::{Method::POST, MockServer};
+
+    #[tokio::test]
+    async fn stream_payloads_collects_multiple_pages() {
+        let server = MockServer::start_async().await;
+        let service = QdrantService {
+            client: reqwest::Client::builder()
+                .user_agent("rusty-mem-test")
+                .build()
+                .expect("client"),
+            base_url: server.base_url(),
+            api_key: None,
+        };
+
+        let first = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/collections/demo/points/scroll")
+                    .body_contains("\"offset\":null");
+                then.status(200).json_body(json!({
+                    "result": {
+                        "points": [
+                            { "payload": { "value": 1 } }
+                        ],
+                        "next_page_offset": { "offset": 1 }
+                    }
+                }));
+            })
+            .await;
+
+        let second = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/collections/demo/points/scroll")
+                    .body_contains("\"offset\":{\"offset\":1}");
+                then.status(200).json_body(json!({
+                    "result": {
+                        "points": [
+                            { "payload": { "value": 2 } }
+                        ],
+                        "next_page_offset": null
+                    }
+                }));
+            })
+            .await;
+
+        let stream = stream_payloads(&service, "demo", json!(["value"]), None);
+        pin_mut!(stream);
+        let mut items = Vec::new();
+        while let Some(item) = stream.next().await {
+            items.push(item.expect("payload"));
+        }
+
+        first.assert();
+        second.assert();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].get("value").and_then(Value::as_i64), Some(1));
+        assert_eq!(items[1].get("value").and_then(Value::as_i64), Some(2));
+    }
+
+    #[tokio::test]
+    async fn stream_payloads_with_ids_collects_multiple_pages() {
+        let server = MockServer::start_async().await;
+        let service = QdrantService {
+            client: reqwest::Client::builder()
+                .user_agent("rusty-mem-test")
+                .build()
+                .expect("client"),
+            base_url: server.base_url(),
+            api_key: None,
+        };
+
+        let first_page = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/collections/demo/points/scroll")
+                    .body_contains("\"offset\":null");
+                then.status(200).json_body(json!({
+                    "result": {
+                        "points": [
+                            { "id": "a", "payload": { "value": 10 } }
+                        ],
+                        "next_page_offset": { "offset": 2 }
+                    }
+                }));
+            })
+            .await;
+
+        let second_page = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/collections/demo/points/scroll")
+                    .body_contains("\"offset\":{\"offset\":2}");
+                then.status(200).json_body(json!({
+                    "result": {
+                        "points": [
+                            { "id": "b", "payload": { "value": 20 } }
+                        ],
+                        "next_page_offset": null
+                    }
+                }));
+            })
+            .await;
+
+        let stream = stream_payloads_with_ids(&service, "demo", json!(["value"]), None);
+        pin_mut!(stream);
+        let mut items = Vec::new();
+        while let Some(item) = stream.next().await {
+            items.push(item.expect("entry"));
+        }
+
+        first_page.assert();
+        second_page.assert();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].0, "a");
+        assert_eq!(items[1].0, "b");
+    }
+}


### PR DESCRIPTION
Summary

- Modularize summarization pipeline:
  - Extract I/O helpers: fetch episodic, persist semantic summary
  - Add idempotency helpers and deterministic summary key usage
  - Add strategy selection with abstractive fallback → extractive
- Qdrant streaming scroll utilities to remove pagination loops
  - New `src/qdrant/scroller.rs` used by client `scroll_payloads*`
- Split `ProcessingService` lifecycle
  - `try_new()` (sync) + `init().await()` (async) and keep `new().await`
- MCP server registry for resources/tools
  - New `src/mcp/registry.rs`, `RustyMemMcpServer` wires registry
- Chunking performance + ergonomics
  - Binary search for trim/tail token budget
  - Named divisors for chunk sizing
- Docs cleanup
  - Remove obsolete `REFACTOR_PLAN.md` and `recommendations.md` from the repo

Validation

- Ran `./scripts/verify.sh` (fmt, clippy, test): all green
- Unit tests: 58 passed, 0 failed
- Markdown lint: `dprint check` clean

Notes

- Public behavior remains identical; abstractive errors log and fall back to extractive
- Development docs updated to reference new structure and lifecycle

Requesting review to merge into `main`. 